### PR TITLE
References counter for Clinical Record structures

### DIFF
--- a/pyehr/ehr/services/dbmanager/dbservices/__init__.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/__init__.py
@@ -177,7 +177,12 @@ class DBServices(object):
                 if not r.is_persistent:
                     r.increase_version()
             encoded_records = [driver.encode_record(r) for r in ehr_records]
-            saved, errors = driver.add_records(encoded_records, skip_existing_duplicated)
+            try:
+                saved, errors = driver.add_records(encoded_records, skip_existing_duplicated)
+            except Exception, exc:
+                for ehr in ehr_records:
+                    self.index_service.check_structure_counter(ehr.structure_id)
+                raise exc
             errors = [driver.decode_record(e) for e in errors]
         saved_struct_counter = Counter()
         for rec in ehr_records:

--- a/pyehr/ehr/services/dbmanager/dbservices/__init__.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/__init__.py
@@ -6,6 +6,8 @@ from pyehr.ehr.services.dbmanager.errors import CascadeDeleteError, RedundantUpd
     RecordRestoreUnecessaryError, OperationNotAllowedError, ConfigurationError
 from pyehr.ehr.services.dbmanager.dbservices.version_manager import VersionManager
 
+from collections import Counter
+
 
 class DBServices(object):
     """
@@ -140,7 +142,13 @@ class DBServices(object):
             # calculate and set the structure ID for the given record
             self._set_structure_id(ehr_record)
             with drf.get_driver() as driver:
-                driver.add_record(driver.encode_record(ehr_record))
+                try:
+                    driver.add_record(driver.encode_record(ehr_record))
+                except Exception, e:
+                    # if a new structure was created, delete it (reference counter is 0)
+                    self.index_service.check_structure_counter(ehr_record.structure_id)
+                    raise e
+                self.index_service.increase_structure_counter(ehr_record.structure_id)
         patient_record = self._add_ehr_record(patient_record, ehr_record)
         return ehr_record, patient_record
 
@@ -171,6 +179,15 @@ class DBServices(object):
             encoded_records = [driver.encode_record(r) for r in ehr_records]
             saved, errors = driver.add_records(encoded_records, skip_existing_duplicated)
             errors = [driver.decode_record(e) for e in errors]
+        saved_struct_counter = Counter()
+        for rec in ehr_records:
+            if rec.record_id in saved:
+                saved_struct_counter[rec.structure_id] += 1
+        error_struct_counter = set([rec.record_id for rec in errors])
+        for struct, counter in saved_struct_counter.iteritems():
+            self.index_service.increase_structure_counter(struct, counter)
+        for struct in error_struct_counter:
+            self.index_service.check_structure_counter(struct)
         saved_ehr_records = [ehr for ehr in ehr_records if ehr.record_id in saved]
         patient_record = self._add_ehr_records(patient_record, saved_ehr_records)
         return saved_ehr_records, patient_record, errors
@@ -535,6 +552,7 @@ class DBServices(object):
         drf = self._get_drivers_factory(self.ehr_repository)
         with drf.get_driver() as driver:
             driver.delete_record(ehr_record.record_id)
+            self.index_service.decrease_structure_counter(ehr_record.structure_id)
         if reset_history:
             self.version_manager.remove_revisions(ehr_record.record_id)
         return None
@@ -543,6 +561,11 @@ class DBServices(object):
         drf = self._get_drivers_factory(self.ehr_repository)
         with drf.get_driver() as driver:
             driver.delete_records_by_id([ehr.record_id for ehr in ehr_records])
+            struct_id_counter = Counter()
+            for rec in ehr_records:
+                struct_id_counter[rec.structure_id] += 1
+            for str_id, str_count in struct_id_counter.iteritems():
+                self.index_service.decrease_structure_counter(str_id, str_count)
         if reset_history:
             for ehr in ehr_records:
                 self.version_manager.remove_revisions(ehr.record_id)

--- a/pyehr/ehr/services/dbmanager/dbservices/index_service.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/index_service.py
@@ -124,7 +124,10 @@ class IndexService(object):
         record_root.append(record)
         record_hash = self._get_record_hash(record)
         record_id = record_id or uuid4().hex
-        record_root.append(etree.Element('references_counter', {'hits': '1'}))
+        # new records are created with a reference counter set to 0, only when
+        # the reference counter will be increased only after the record will
+        # actually be saved on the DB
+        record_root.append(etree.Element('references_counter', {'hits': '0'}))
         record_root.append(etree.Element('structure_id', {'str_hash': record_hash,
                                                           'uid': record_id}))
         return record_root, record_id

--- a/pyehr/ehr/services/dbmanager/dbservices/index_service.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/index_service.py
@@ -178,6 +178,23 @@ class IndexService(object):
     def _update_document_references_counter(self, doc, update_value):
         doc.find("references_counter").set("hits", str(update_value))
         return doc
+
+    def check_structure_counter(self, structure_id):
+        """
+        Check if a structure with ID *structure_id* has a references counter equal to 0.
+        If so, delete the structure because it is not referenced by a clinical record.
+
+        :param structure_id: the ID of the structure that will be checked
+        """
+        doc = self._get_structure_by_id(structure_id)
+        if doc is not None:
+            doc_count = self._get_document_reference_counter(doc)
+            if doc_count == 0:
+                self.basex_client.delete_document(structure_id)
+            else:
+                self.logger.debug("References counter for structure %s id %d",
+                                  doc_count, structure_id)
+
     def increase_structure_counter(self, structure_id, increase_value=1):
         """
         Increase the value of the references counter of the structure with the

--- a/pyehr/ehr/services/dbmanager/dbservices/index_service.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/index_service.py
@@ -136,6 +136,11 @@ class IndexService(object):
         self.basex_client.add_document(record, structure_key)
         return structure_key
 
+    def _get_structure_by_id(self, structure_id):
+        if not self.basex_client:
+            self.connect()
+        return self.basex_client.get_document(structure_id)
+
     def _extract_structure_id_from_xml(self, xml_doc):
         return xml_doc.find('structure_id').get('uid')
 

--- a/pyehr/ehr/services/dbmanager/dbservices/index_service.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/index_service.py
@@ -37,7 +37,7 @@ class IndexService(object):
         return res
 
     @staticmethod
-    def get_structure(ehr_record, parent_key=[]):
+    def get_structure(ehr_record, parent_key=None):
         def is_archetype(doc):
             return 'archetype_class' in doc
 
@@ -93,11 +93,13 @@ class IndexService(object):
                         archetypes.extend(a_from_list)
             return archetypes
 
-        # TODO: sort records structure?
+        if parent_key is None:
+            parent_key = []
         root = etree.Element(
             'archetype',
             {'class': ehr_record['archetype_class'], 'path_from_parent': build_path(parent_key)}
         )
+
         parent_key = []
         for k, x in sorted(ehr_record['archetype_details'].iteritems()):
             pk = parent_key + [k]

--- a/test/pyehr/ehr/services/dbmanager/dbservices/test_dbservices.py
+++ b/test/pyehr/ehr/services/dbmanager/dbservices/test_dbservices.py
@@ -24,11 +24,6 @@ class TestDBServices(unittest.TestCase):
         self.conf = sconf.get_db_configuration()
         self.index_conf = sconf.get_index_configuration()
 
-    def _delete_index_db(self, dbs):
-        dbs.index_service.connect()
-        dbs.index_service.basex_client.delete_database()
-        dbs.index_service.disconnect()
-
     def test_save_patient(self):
         dbs = DBServices(**self.conf)
         dbs.set_index_service(**self.index_conf)
@@ -39,7 +34,6 @@ class TestDBServices(unittest.TestCase):
         self.assertTrue(pat_rec.active)
         # cleanup
         dbs.delete_patient(pat_rec)
-        self._delete_index_db(dbs)
 
     def test_save_ehr_record(self):
         dbs = DBServices(**self.conf)
@@ -59,7 +53,6 @@ class TestDBServices(unittest.TestCase):
         self.assertEqual(pat_rec.ehr_records[0], ehr_rec)
         # cleanup
         dbs.delete_patient(pat_rec, cascade_delete=True)
-        self._delete_index_db(dbs)
 
     def test_save_ehr_records(self):
         dbs = DBServices(**self.conf)
@@ -90,7 +83,6 @@ class TestDBServices(unittest.TestCase):
         self.assertEqual(len(pat_rec.ehr_records), 15)
         # cleanup
         dbs.delete_patient(pat_rec, cascade_delete=True)
-        self._delete_index_db(dbs)
 
     def test_remove_ehr_record(self):
         dbs = DBServices(**self.conf)
@@ -112,7 +104,6 @@ class TestDBServices(unittest.TestCase):
         # clenup
         dbs.delete_patient(pat_rec_1)
         dbs.delete_patient(pat_rec_2, cascade_delete=True)
-        self._delete_index_db(dbs)
 
     def test_load_ehr_records(self):
         dbs = DBServices(**self.conf)
@@ -134,7 +125,6 @@ class TestDBServices(unittest.TestCase):
             self.assertNotEqual(len(ehr.ehr_data.archetype_details), 0)
         # cleanup
         dbs.delete_patient(pat_rec, cascade_delete=True)
-        self._delete_index_db(dbs)
 
     def _get_active_records_count(self, patient_record, counter):
         for ehr in patient_record.ehr_records:
@@ -162,7 +152,6 @@ class TestDBServices(unittest.TestCase):
         self.assertNotIn('active', active_records)
         # cleanup
         dbs.delete_patient(pat_rec, cascade_delete=True)
-        self._delete_index_db(dbs)
 
     def test_hide_ehr_record(self):
         dbs = DBServices(**self.conf)
@@ -190,7 +179,6 @@ class TestDBServices(unittest.TestCase):
         self.assertEqual(active_records['hidden'], 10)
         # cleanup
         dbs.delete_patient(pat_rec, cascade_delete=True)
-        self._delete_index_db(dbs)
 
     def test_move_ehr_record(self):
         dbs = DBServices(**self.conf)
@@ -209,7 +197,6 @@ class TestDBServices(unittest.TestCase):
         # cleanup
         dbs.delete_patient(pat_rec_1)
         dbs.delete_patient(pat_rec_2, cascade_delete=True)
-        self._delete_index_db(dbs)
 
     def test_get_ehr_record(self):
         dbs = DBServices(**self.conf)
@@ -230,9 +217,8 @@ class TestDBServices(unittest.TestCase):
         # right ehr_record_id and patient_id
         e = dbs.get_ehr_record(crec_id, p.record_id)
         self.assertIsInstance(e, ClinicalRecord)
-        #cleanup
+        # cleanup
         dbs.delete_patient(p, cascade_delete=True)
-        self._delete_index_db(dbs)
 
 
 def suite():

--- a/test/pyehr/ehr/services/dbmanager/dbservices/test_version_manager.py
+++ b/test/pyehr/ehr/services/dbmanager/dbservices/test_version_manager.py
@@ -45,9 +45,6 @@ class TestVersionManager(unittest.TestCase):
     def tearDown(self):
         if self.patient:
             self.dbs.delete_patient(self.patient, cascade_delete=True)
-        self.dbs.index_service.connect()
-        self.dbs.index_service.basex_client.delete_database()
-        self.dbs.index_service.disconnect()
         self.dbs = None
 
 

--- a/test/pyehr/ehr/services/dbmanager/querymanager/test_queries_runner.py
+++ b/test/pyehr/ehr/services/dbmanager/querymanager/test_queries_runner.py
@@ -28,13 +28,7 @@ class TestQueriesRunner(unittest.TestCase):
     def tearDown(self):
         for p in self.patients:
             self.dbs.delete_patient(p, cascade_delete=True)
-            self._delete_index_db()
         self.patients = None
-
-    def _delete_index_db(self):
-        self.dbs.index_service.connect()
-        self.dbs.index_service.basex_client.delete_database()
-        self.dbs.index_service.disconnect()
 
     def _get_quantity(self, value, units):
         return {

--- a/test/pyehr/ehr/services/dbmanager/querymanager/test_querymanager.py
+++ b/test/pyehr/ehr/services/dbmanager/querymanager/test_querymanager.py
@@ -27,14 +27,8 @@ class TestQueryManager(unittest.TestCase):
     def tearDown(self):
         for p in self.patients:
             self.dbs.delete_patient(p, cascade_delete=True)
-        self._delete_index_db()
         self.patients = None
         pass
-
-    def _delete_index_db(self):
-        self.dbs.index_service.connect()
-        self.dbs.index_service.basex_client.delete_database()
-        self.dbs.index_service.disconnect()
 
     def _get_quantity(self, value, units):
         return {

--- a/test/services/test_dbservice.py
+++ b/test/services/test_dbservice.py
@@ -32,15 +32,6 @@ class TestDBService(unittest.TestCase):
             'save_patients': 'batch/save/patients'
         }
 
-    def tearDown(self):
-        sconf = get_service_configuration(CONF_FILE)
-        index_config = sconf.get_index_configuration()
-        index_config['db'] = index_config.pop('database')
-        index_service = IndexService(**index_config)
-        index_service.connect()
-        index_service.basex_client.delete_database()
-        index_service.disconnect()
-
     def _get_path(self, path, patient_id=None, ehr_record_id=None, action=None):
         path_params = [self.dbservice_uri, path]
         if patient_id:

--- a/test/services/test_queryservice.py
+++ b/test/services/test_queryservice.py
@@ -30,13 +30,7 @@ class TestQueryService(unittest.TestCase):
     def tearDown(self):
         for p in self.patients:
             self.dbs.delete_patient(p, cascade_delete=True)
-        self._delete_index_db()
         self.patients = None
-
-    def _delete_index_db(self):
-        self.dbs.index_service.connect()
-        self.dbs.index_service.basex_client.delete_database()
-        self.dbs.index_service.disconnect()
 
     def _get_quantity(self, value, units):
         return {


### PR DESCRIPTION
Implemented a mechanism to keep trace of the number of records that belong to a specific structure type.
When records are added, structures counter is increased; when records are removed, structures counter is decreased.
If a structure counter reaches 0, structure will be removed from index database.
