### PR TITLE
Always check ClinicalRecord structure when updating it

### DIFF
--- a/pyehr/ehr/services/dbmanager/dbservices/__init__.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/__init__.py
@@ -3,7 +3,7 @@ from pyehr.utils import get_logger
 from pyehr.ehr.services.dbmanager.dbservices.index_service import IndexService
 from pyehr.ehr.services.dbmanager.dbservices.wrappers import PatientRecord, ClinicalRecord
 from pyehr.ehr.services.dbmanager.errors import CascadeDeleteError, RedundantUpdateError,\
-    RecordRestoreUnecessaryError, OperationNotAllowedError, ConfigurationError
+    RecordRestoreUnnecessaryError, OperationNotAllowedError, ConfigurationError
 from pyehr.ehr.services.dbmanager.dbservices.version_manager import VersionManager
 
 from collections import Counter
@@ -246,7 +246,7 @@ class DBServices(object):
 
     def _check_unecessary_restore(self, ehr_record):
         if ehr_record.version == 1:
-            raise RecordRestoreUnecessaryError('Record %s already at original revision' %
+            raise RecordRestoreUnnecessaryError('Record %s already at original revision' %
                                                ehr_record.record_id)
         elif ehr_record.version == 0:
             raise OperationNotAllowedError('Record %s is not mapped in the DB, unable to restore' %

--- a/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
@@ -195,10 +195,12 @@ class VersionManager(object):
                                             convert_to_clinical_record=True)
         if not original_record:
             raise MissingRevisionError('Unable to retrieve version %d for record %s' %
-                                      (revision, record_id))
+                                       (revision, record_id))
         drf = self._get_drivers_factory()
         with drf.get_driver() as driver:
+            old_rec_struct = driver.get_values_by_record_id(record_id, ["ehr_structure_id"])["ehr_structure_id"]
             driver.delete_record(record_id)
+            self.index_service.decrease_structure_counter(old_rec_struct)
             driver.add_record(driver.encode_record(original_record))
         drf = self._get_drivers_factory(True)
         with drf.get_driver() as driver:

--- a/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
@@ -154,7 +154,7 @@ class VersionManager(object):
         setattr(record, field, value)
         return record
 
-    def add_to_list(self, record, list_label, element, last_update_label):
+    def add_to_list(self, record, list_label, element, last_update_label=None):
         current_revision = self._get_current_revision(record.record_id)
         self._check_optimistic_lock(current_revision, record.version)
         self._move_record_to_archive(current_revision)
@@ -166,7 +166,7 @@ class VersionManager(object):
         record.increase_version()
         return record
 
-    def extend_list(self, record, list_label, elements, last_update_label):
+    def extend_list(self, record, list_label, elements, last_update_label=None):
         current_revision = self._get_current_revision(record.record_id)
         self._check_optimistic_lock(current_revision, record.version)
         self._move_record_to_archive(current_revision)
@@ -178,7 +178,7 @@ class VersionManager(object):
         record.increase_version()
         return record
 
-    def remove_from_list(self, record, list_label, element, last_update_label):
+    def remove_from_list(self, record, list_label, element, last_update_label=None):
         current_revision = self._get_current_revision(record.record_id)
         self._check_optimistic_lock(current_revision, record.version)
         self._move_record_to_archive(current_revision)

--- a/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
@@ -94,7 +94,9 @@ class VersionManager(object):
             if record:
                 rec = driver.decode_record(record)
                 if convert_to_clinical_record:
-                    return rec.convert_to_clinical_record()
+                    crec = rec.convert_to_clinical_record()
+                    self._set_structure_id(crec)
+                    return crec
                 else:
                     return rec
             else:

--- a/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
@@ -125,9 +125,14 @@ class VersionManager(object):
         drf = self._get_drivers_factory()
         with drf.get_driver() as driver:
             new_record.increase_version()
+            struct_changed = self._set_structure_id(new_record)
             last_update = driver.replace_record(new_record.record_id,
                                                 driver.encode_record(new_record),
                                                 'last_update')
+            if struct_changed:
+                self.index_service.increase_structure_counter(new_record.structure_id)
+            else:
+                self.index_service.check_structure_counter(new_record.structure_id)
             new_record.last_update = last_update
         return new_record
 

--- a/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
@@ -107,6 +107,16 @@ class VersionManager(object):
                          driver.get_revisions_by_ehr_id(record_id)]
         return sorted(revisions, key=attrgetter('version'), reverse=reverse_ordering)
 
+    def _set_structure_id(self, ehr_record):
+        self._check_index_service()
+        ehr_data = ehr_record.ehr_data.to_json()
+        structure_id = self.index_service.get_structure_id(ehr_data)
+        if structure_id == ehr_record.structure_id:
+            return False
+        else:
+            ehr_record.structure_id = structure_id
+            return True
+
     def update_record(self, new_record):
         current_revision = self._get_current_revision(new_record.record_id)
         self._check_redundant_update(new_record, current_revision)

--- a/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
@@ -9,7 +9,7 @@ except ImportError:
 from pyehr.ehr.services.dbmanager.drivers.factory import DriversFactory
 from pyehr.utils import get_logger
 from pyehr.ehr.services.dbmanager.errors import OptimisticLockError,\
-    RedundantUpdateError, MissingRevisionError
+    RedundantUpdateError, MissingRevisionError, ConfigurationError
 
 
 class VersionManager(object):
@@ -51,6 +51,10 @@ class VersionManager(object):
             logger=self.logger,
             index_service=self.index_service,
         )
+
+    def _check_index_service(self):
+        if not self.index_service:
+            raise ConfigurationError('Operation not allowed, missing IndexService')
 
     def _check_redundant_update(self, new_record, old_record):
         new_record_hash = md5()

--- a/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/version_manager.py
@@ -200,8 +200,10 @@ class VersionManager(object):
         with drf.get_driver() as driver:
             old_rec_struct = driver.get_values_by_record_id(record_id, ["ehr_structure_id"])["ehr_structure_id"]
             driver.delete_record(record_id)
-            self.index_service.decrease_structure_counter(old_rec_struct)
             driver.add_record(driver.encode_record(original_record))
+            if old_rec_struct != original_record.structure_id:
+                self.index_service.decrease_structure_counter(old_rec_struct)
+                self.index_service.increase_structure_counter(original_record.structure_id)
         drf = self._get_drivers_factory(True)
         with drf.get_driver() as driver:
             del_count = driver.delete_later_versions(record_id, revision-1)

--- a/pyehr/ehr/services/dbmanager/dbservices/wrappers.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/wrappers.py
@@ -261,7 +261,6 @@ class ClinicalRecord(Record):
             creation_time=self.creation_time,
             last_update=self.last_update,
             active=self.active,
-            structure_id=self.structure_id,
             version=self.version
         )
 
@@ -269,9 +268,10 @@ class ClinicalRecord(Record):
 class ClinicalRecordRevision(ClinicalRecord):
 
     def __init__(self, ehr_data, record_id, patient_id, creation_time=None, last_update=None,
-                 active=True, structure_id=None, version=0):
-        super(ClinicalRecordRevision, self).__init__(ehr_data, creation_time, last_update,
-                                                     active, record_id, structure_id, version)
+                 active=True, version=0):
+        super(ClinicalRecordRevision, self).__init__(ehr_data=ehr_data, creation_time=creation_time,
+                                                     last_update=last_update, active=active,
+                                                     record_id=record_id, version=version)
         self.record_id = record_id
         self._set_patient_id(patient_id)
 
@@ -284,7 +284,6 @@ class ClinicalRecordRevision(ClinicalRecord):
             'creation_time': float,
             'last_update': float,
             'active': bool,
-            'record_id': str,
             'patient_id': str,
             'version': int
         })
@@ -296,7 +295,6 @@ class ClinicalRecordRevision(ClinicalRecord):
             last_update=self.last_update,
             active=self.active,
             record_id=self.record_id['_id'],
-            structure_id=self.structure_id,
             version=self.version
         )
         crec._set_patient_id(self.patient_id)

--- a/pyehr/ehr/services/dbmanager/dbservices/wrappers.py
+++ b/pyehr/ehr/services/dbmanager/dbservices/wrappers.py
@@ -261,6 +261,7 @@ class ClinicalRecord(Record):
             creation_time=self.creation_time,
             last_update=self.last_update,
             active=self.active,
+            structure_id=self.structure_id,
             version=self.version
         )
 
@@ -268,10 +269,9 @@ class ClinicalRecord(Record):
 class ClinicalRecordRevision(ClinicalRecord):
 
     def __init__(self, ehr_data, record_id, patient_id, creation_time=None, last_update=None,
-                 active=True, version=0):
-        super(ClinicalRecordRevision, self).__init__(ehr_data=ehr_data, creation_time=creation_time,
-                                                     last_update=last_update, active=active,
-                                                     record_id=record_id, version=version)
+                 active=True, structure_id=None, version=0):
+        super(ClinicalRecordRevision, self).__init__(ehr_data, creation_time, last_update,
+                                                     active, record_id, structure_id, version)
         self.record_id = record_id
         self._set_patient_id(patient_id)
 
@@ -284,6 +284,7 @@ class ClinicalRecordRevision(ClinicalRecord):
             'creation_time': float,
             'last_update': float,
             'active': bool,
+            'record_id': str,
             'patient_id': str,
             'version': int
         })
@@ -295,6 +296,7 @@ class ClinicalRecordRevision(ClinicalRecord):
             last_update=self.last_update,
             active=self.active,
             record_id=self.record_id['_id'],
+            structure_id=self.structure_id,
             version=self.version
         )
         crec._set_patient_id(self.patient_id)

--- a/pyehr/ehr/services/dbmanager/drivers/elastic_search.py
+++ b/pyehr/ehr/services/dbmanager/drivers/elastic_search.py
@@ -1570,6 +1570,10 @@ class ElasticSearchDriver(DriverInterface):
             res=self.get_records_by_query_scan(query,fields,limit)
         return res
 
+    def get_values_by_record_id(self, record_id, values_list):
+        res = self.client.get_source(index=self.database, id=record_id, _source_include=values_list)
+        return decode_dict(res)
+
     def get_records_by_query_scan(self, query,fields=None,limit=0):
         """
         Retrieve all records matching the given query

--- a/pyehr/ehr/services/dbmanager/drivers/elastic_search.py
+++ b/pyehr/ehr/services/dbmanager/drivers/elastic_search.py
@@ -398,7 +398,6 @@ class ElasticSearchDriver(DriverInterface):
             last_update=record['last_update'],
             active=record['active'],
             record_id={'_id': record['_id'].rsplit('_', 1)[0],'_revision' : int(record['_id'].rsplit('_', 1)[1])},
-            structure_id=record['ehr_structure_id'],
             version=int(record['_id'].rsplit('_', 1)[1]),
         )
 

--- a/pyehr/ehr/services/dbmanager/drivers/elastic_search.py
+++ b/pyehr/ehr/services/dbmanager/drivers/elastic_search.py
@@ -398,6 +398,7 @@ class ElasticSearchDriver(DriverInterface):
             last_update=record['last_update'],
             active=record['active'],
             record_id={'_id': record['_id'].rsplit('_', 1)[0],'_revision' : int(record['_id'].rsplit('_', 1)[1])},
+            structure_id=record['ehr_structure_id'],
             version=int(record['_id'].rsplit('_', 1)[1]),
         )
 

--- a/pyehr/ehr/services/dbmanager/drivers/interface.py
+++ b/pyehr/ehr/services/dbmanager/drivers/interface.py
@@ -135,6 +135,13 @@ class DriverInterface(object):
         pass
 
     @abstractmethod
+    def get_values_by_record_id(self, record_id, values_list):
+        """
+        Retrieve values in *values_list* from record with ID *record_id*
+        """
+        pass
+
+    @abstractmethod
     def count_records_by_query(self, selector):
         """
         Retrieve the number of records matching the given query

--- a/pyehr/ehr/services/dbmanager/drivers/mongo_pm2.py
+++ b/pyehr/ehr/services/dbmanager/drivers/mongo_pm2.py
@@ -429,6 +429,23 @@ class MongoDriverPM2(DriverInterface):
         self._check_connection()
         return (decode_dict(rec) for rec in self.collection.find(selector, fields, limit=limit))
 
+    def get_values_by_record_id(self, record_id, values_list):
+        """
+        Retrieve values in *values_list* from record with ID *record_id*
+
+        :param record_id: the ID of the record that must be selected
+        :type record_id: str
+        :param values_list: a list of field labels that must be extracted from the record
+        :type values_list: list
+        :return: a dictionary with *values_list* elements as keys
+        :rtype: dict
+        """
+        self._check_connection()
+        selector = dict([(value, 1) for value in values_list])
+        if '_id' not in values_list:
+            selector['_id'] = 0
+        return self.collection.find_one(record_id, selector)
+
     def count_records_by_query(self, selector):
         """
         Retrieve the number of records matching the given query

--- a/pyehr/ehr/services/dbmanager/drivers/mongo_pm2.py
+++ b/pyehr/ehr/services/dbmanager/drivers/mongo_pm2.py
@@ -288,7 +288,6 @@ class MongoDriverPM2(DriverInterface):
             last_update=record['last_update'],
             active=record['active'],
             record_id=record['_id'],
-            structure_id=record['ehr_structure_id'],
             version=record.get('_version'),
         )
 

--- a/pyehr/ehr/services/dbmanager/drivers/mongo_pm2.py
+++ b/pyehr/ehr/services/dbmanager/drivers/mongo_pm2.py
@@ -288,6 +288,7 @@ class MongoDriverPM2(DriverInterface):
             last_update=record['last_update'],
             active=record['active'],
             record_id=record['_id'],
+            structure_id=record['ehr_structure_id'],
             version=record.get('_version'),
         )
 

--- a/pyehr/ehr/services/dbmanager/errors.py
+++ b/pyehr/ehr/services/dbmanager/errors.py
@@ -70,7 +70,7 @@ class RecordRestoreFailedError(Exception):
     pass
 
 
-class RecordRestoreUnecessaryError(Exception):
+class RecordRestoreUnnecessaryError(Exception):
     pass
 
 
@@ -80,6 +80,7 @@ class MissingRevisionError(Exception):
 
 class OperationNotAllowedError(Exception):
     pass
+
 
 class QueryCreationException(Exception):
     pass

--- a/test/pyehr/ehr/services/dbmanager/dbservices/test_version_manager.py
+++ b/test/pyehr/ehr/services/dbmanager/dbservices/test_version_manager.py
@@ -28,6 +28,23 @@ class TestVersionManager(unittest.TestCase):
                                  }})
         return ClinicalRecord(arch)
 
+    def _create_random_complex_archetype(self):
+        arch1 = ArchetypeInstance('openEHR-EHR-OBSERVATION.dummy-observation.v1',
+                                  {
+                                      'data': {
+                                          'at0001': random.randint(1, 99),
+                                          'at0002': 'just a text field'
+                                      }
+                                  })
+        arch2 = ArchetypeInstance('openEHR-EHR-COMPOSITION.dummy-composition.v1',
+                                  {
+                                      'data': {
+                                          'at1001': random.randint(1, 100),
+                                          'at1002': arch1
+                                      }
+                                  })
+        return arch2
+
     def build_dataset(self):
         self._create_random_patient()
         crec = self._create_random_clinical_record()
@@ -46,7 +63,6 @@ class TestVersionManager(unittest.TestCase):
         if self.patient:
             self.dbs.delete_patient(self.patient, cascade_delete=True)
         self.dbs = None
-
 
     def test_record_update(self):
         crec = self.build_dataset()
@@ -99,6 +115,21 @@ class TestVersionManager(unittest.TestCase):
         self.assertEqual(crec.to_json(), crec_rev_2)
         crec = self.dbs.restore_previous_ehr_version(crec)
         self.assertEqual(crec.to_json(), crec_rev_1)
+
+    def test_record_reindex(self):
+        crec = self.build_dataset()
+        crec_struct_id = crec.structure_id
+        crec.ehr_data = self._create_random_complex_archetype()
+        crec = self.dbs.update_ehr_record(crec)
+        self.assertNotEqual(crec_struct_id, crec.structure_id)
+        self.assertEqual(crec.version, 2)
+        self.assertGreater(crec.last_update, crec.creation_time)
+        self.assertEqual(crec.ehr_data.archetype_class, 'openEHR-EHR-COMPOSITION.dummy-composition.v1')
+        crec_struct_id = crec.structure_id
+        crec, deleted_revisions = self.dbs.restore_original_ehr(crec)
+        self.assertNotEqual(crec.structure_id, crec_struct_id)
+        self.assertEqual(crec.version, 1)
+        self.assertEqual(crec.ehr_data.archetype_class, 'openEHR-EHR-OBSERVATION.dummy-observation.v1')
 
     def test_get_revision(self):
         crec = self.build_dataset()
@@ -186,6 +217,7 @@ def suite():
     suite.addTest(TestVersionManager('test_record_restore'))
     suite.addTest(TestVersionManager('test_record_restore_original'))
     suite.addTest(TestVersionManager('test_record_restore_previous_revision'))
+    suite.addTest(TestVersionManager('test_record_reindex'))
     suite.addTest(TestVersionManager('test_get_revision'))
     suite.addTest(TestVersionManager('test_get_revisions'))
     suite.addTest(TestVersionManager('test_optimistic_lock_error'))

--- a/test/pyehr/ehr/services/dbmanager/dbservices/test_version_manager.py
+++ b/test/pyehr/ehr/services/dbmanager/dbservices/test_version_manager.py
@@ -3,7 +3,7 @@ from pyehr.ehr.services.dbmanager.dbservices import DBServices
 from pyehr.ehr.services.dbmanager.dbservices.wrappers import PatientRecord,\
     ClinicalRecord, ClinicalRecordRevision, ArchetypeInstance
 from pyehr.ehr.services.dbmanager.errors import OptimisticLockError,\
-    RedundantUpdateError, MissingRevisionError, RecordRestoreUnecessaryError,\
+    RedundantUpdateError, MissingRevisionError, RecordRestoreUnnecessaryError,\
     OperationNotAllowedError
 from pyehr.utils.services import get_service_configuration
 
@@ -197,9 +197,9 @@ class TestVersionManager(unittest.TestCase):
         with self.assertRaises(MissingRevisionError) as ctx:
             self.dbs.restore_ehr_version(crec2, 5)
 
-    def test_record_restore_unecessary_error(self):
+    def test_record_restore_unnecessary_error(self):
         crec = self.build_dataset()
-        with self.assertRaises(RecordRestoreUnecessaryError) as ctx:
+        with self.assertRaises(RecordRestoreUnnecessaryError) as ctx:
             self.dbs.restore_previous_ehr_version(crec)
             self.dbs.restore_original_ehr(crec)
 
@@ -223,7 +223,7 @@ def suite():
     suite.addTest(TestVersionManager('test_optimistic_lock_error'))
     suite.addTest(TestVersionManager('test_redundant_update_error'))
     suite.addTest(TestVersionManager('test_missing_revision_error'))
-    suite.addTest(TestVersionManager('test_record_restore_unecessary_error'))
+    suite.addTest(TestVersionManager('test_record_restore_unnecessary_error'))
     suite.addTest(TestVersionManager('test_operation_not_allowed_error'))
     return suite
 


### PR DESCRIPTION
When a ClinicalRecord object is modified, the VersionManager module will check if the record's structure is changed and updates index_service properly. The same thing happens when a record is restored to one of its previous versions.
